### PR TITLE
Add Catnip as transitive SwiftPM dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,10 @@ import PackageDescription
 let version: String = "26.20.1-RC"
 let urlVersion: String = "26.20.1"
 let checksum: String = "127c5a0a4e9f56f1fac664e8713c61f1da78dfe4925b5dac198330ba57857e8e"
+let catnipVersion = Version(0, 0, 5)
 
 let dependencies: [Target.Dependency] = [
+    .product(name: "Catnip", package: "catnip-spm"),
     .product(name: "WebRTC", package: "WebRTC"),
     .product(name: "Lottie", package: "lottie-spm"),
     .product(name: "OpenSSL", package: "OpenSSL")
@@ -24,6 +26,7 @@ let package = Package(
             targets: ["VideoIDSDK", "_VideoIDSDKStub"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/signicat/catnip-spm.git", exact: catnipVersion),
         .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.4.3"),
         .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", from: "3.2.2000"),
         .package(url: "https://github.com/stasel/WebRTC.git", exact: "134.0.0")

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This ensures you always get the latest compatible version (e.g., `1.41.0`, `1.99
 
 4. Add `VideoIDSDK` to your target.
 
+VideoIDSDK depends transitively on the binary Catnip SwiftPM package for shared runtime UI components. Xcode resolves and embeds `Catnip.framework` automatically when this package is added. App code should continue to import only `VideoIDSDK`; adding Catnip manually is not required.
+
 
 
 Alternatively, add this to your `Package.swift`:
@@ -118,4 +120,3 @@ class AuthorizationResponse: Decodable {
         case authorization
     }
 }
-

--- a/Template.swift
+++ b/Template.swift
@@ -5,8 +5,10 @@ import PackageDescription
 
 let version: String = "REPLACE_VERSION"
 let checksum: String = "REPLACE_CHECKSUM"
+let catnipVersion = Version(0, 0, 5)
 
 let dependencies: [Target.Dependency] = [
+    .product(name: "Catnip", package: "catnip-spm"),
     .product(name: "WebRTC", package: "eidwebrtc-spm"),
     .product(name: "Lottie", package: "lottie-spm"),
     .product(name: "OpenSSL", package: "OpenSSL")
@@ -20,6 +22,7 @@ let package = Package(
             targets: ["VideoIDSDK", "_VideoIDSDKStub"]),
     ],
     dependencies: [
+        .package(url: "https://github.com/signicat/catnip-spm.git", exact: catnipVersion),
         .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.4.3"),
         .package(url: "https://github.com/krzyzanowskim/OpenSSL.git", from: "3.2.2000"),
         .package(url: "https://github.com/signicat/eidwebrtc-spm", from: "1.1.37")
@@ -33,6 +36,5 @@ let package = Package(
                 dependencies: dependencies)
     ]
 )
-
 
 


### PR DESCRIPTION
## Summary

Adds Catnip as an exact transitive dependency of the public VideoIDSDK SwiftPM package. The dependency is declared through the stub target so client apps resolve and embed Catnip.framework automatically when adding VideoIDSDK.

## Context

VideoIDSDK links Catnip dynamically in public binary artifacts. The public SwiftPM package therefore needs to expose the matching Catnip binary package so consumers do not have to add it manually and so downstream SDKs can resolve a single shared Catnip.framework.

## Validation

- swift package --package-path CI-CD/videoidskd-spm dump-package
- git diff --check